### PR TITLE
Fix: Email with Top-level Domains between 2 and 24 character length should be considered valid

### DIFF
--- a/src/validators/validateAttributes.ts
+++ b/src/validators/validateAttributes.ts
@@ -313,7 +313,11 @@ class validateAttributes {
             return false;
         }
 
-        return value.toLowerCase().match(/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/) !== null;
+        /**
+         * Max allowed length for a top-level-domain is 24 characters.
+         * reference to list of top-level-domains: https://data.iana.org/TLD/tlds-alpha-by-domain.txt
+         */
+        return value.toLowerCase().match(/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,24})+$/) !== null;
     };
 
     /**

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -281,6 +281,9 @@ describe('Email', function() {
 
       validator.setData({ value: 'tEst@gtEst.cOm' });
       assert.ok(validator.validate());
+      
+      validator.setData({ value: 'test@test.online' });
+      assert.ok(validator.validate());
     });
   })
 });


### PR DESCRIPTION
Fixes issue #26