### PR TITLE
fix: in error message must show the values

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -39,7 +39,7 @@ export default {
         array: 'The :attribute must have :value items or more.',
         object: 'The :attribute must have :value items or more.',
     },
-    in: 'The :attribute must be one of the following types: :values.',
+    in: 'The :attribute must be one of the following :values.',
     integer: 'The :attribute must be an integer.',
     json: 'The :attribute must be a valid JSON string.',
     lt: {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -39,7 +39,7 @@ export default {
         array: 'The :attribute must have :value items or more.',
         object: 'The :attribute must have :value items or more.',
     },
-    in: 'The selected :attribute is invalid.',
+    in: 'The :attribute must be one of the following types: :values.',
     integer: 'The :attribute must be an integer.',
     json: 'The :attribute must be a valid JSON string.',
     lt: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ export interface ReplaceAttribueInterface {
     replaceDigitsBetween: (payload: replaceAttributePayload) => string;
     replaceDifferent: (payload: replaceAttributePayload) => string;
     replaceEndsWith: (payload: replaceAttributePayload) => string;
+    replaceIn: (payload: replaceAttributePayload) => string;
     replaceMin: (payload: replaceAttributePayload) => string;
     replaceMax: (payload: replaceAttributePayload) => string;
     replaceRequiredWith: (payload: replaceAttributePayload) => string;

--- a/src/validators/replaceAttributes.ts
+++ b/src/validators/replaceAttributes.ts
@@ -114,6 +114,13 @@ const replaceAttributes: ReplaceAttribueInterface = {
     replaceEndsWith: function({ message, parameters }: replaceAttributePayload): string {
         return message.replace(':values', parameters.join(', '));
     },
+    
+    /**
+     * Replace all place-holders for the in rule.
+     */
+    replaceIn: function({ message, parameters }: replaceAttributePayload): string {
+        return message.replace(':values', parameters.join(', '));
+    },
 
     /**
      * Replace all place-holders for the starts_with rule.

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -714,7 +714,7 @@ describe('In', function() {
       assert.equal(validator.validate(), false);
     });
     it('An Error message should be returned in case of failure', function() {
-      assert.equal(validator.errors().first(), 'The selected value is invalid.');
+      assert.equal(validator.errors().first(), 'The value must be one of the following john, any, true, 4.');
     });
     it('Validation should succeed if the field under validation is included in the list of values', function() {
         validator.setData({ value: 'john' });
@@ -748,7 +748,7 @@ describe('In', function() {
       assert.equal(validator.validate(), false);
     });
     it('An Error message should be returned in case of failure', function() {
-      assert.equal(validator.errors().first(), 'The selected value is invalid.');
+      assert.equal(validator.errors().first(), 'The value must be one of the following john, any, true, 4.');
     });
     it('Validation should succeed if all the fields under validation are in included in the list of values', function() {
       validator.setData({ value: ['john', 4, 'true' ] });
@@ -767,7 +767,7 @@ describe('ruleIn Function', function() {
       assert.equal(validator.validate(), false);
     });
     it('An Error message should be returned in case of failure', function() {
-      assert.equal(validator.errors().first(), 'The selected value is invalid.');
+      assert.equal(validator.errors().first(), 'The value must be one of the following john, any, true, 4.');
     });
     it('All the values in the value list will be transformed to a string', function() {
       validator.setData({ value: true }).setRules({ value: ruleIn([ true ])});


### PR DESCRIPTION
Hi ! Thank you for this complete library.

I have fixed the `in` error message by adding the `values` placeholder, like you said in your [docs](https://www.simple-body-validator.com/error-messages/customizing-error-messages#specifying-custom-message-for-a-rule).